### PR TITLE
fix href in blocks html template for next button

### DIFF
--- a/lib/zcash_explorer_web/templates/block/blocks.html.eex
+++ b/lib/zcash_explorer_web/templates/block/blocks.html.eex
@@ -57,7 +57,7 @@
 <% end %>
     
 <%= if !@disable_next do %>
-    <a href="='/blocks?date=<%= @next %>" class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+    <a href="/blocks?date=<%= @next %>" class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
       Next
     </a>
 <% end %>


### PR DESCRIPTION
**Steps to reproduce:**
1. Go to https://zcashblockexplorer.com/blocks?date=2021-11-2 in browser.
2. Scroll to bottom of page and click "Next" button

**Expected Behavior:** Browser should navigate to https://zcashblockexplorer.com/blocks?date=2021-11-3 and show blocks page for that date.

**Actual Behavior:** Browser navigates to https://zcashblockexplorer.com/='/blocks?date=2021-11-3 and shows 'Not Found' page.

**How to fix:** Update faulty href attribute in `lib/zcash_explorer_web/templates/block/blocks.html.eex` on Line 60.

**Screencast:**

https://user-images.githubusercontent.com/13672058/140232116-b6bdd85a-954b-4331-b67e-cc979cfcc000.mp4

